### PR TITLE
Feature/msg builders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "ambur-mcp"
 version = "0.1.0"
 dependencies = [
+ "cosmwasm-std 2.2.2",
  "philabs-cw721-marketplace",
  "rmcp",
  "schemars",
@@ -53,6 +72,127 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+dependencies = [
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+ "itertools",
+ "num-traits",
+ "rayon",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest 0.10.7",
+ "itertools",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rayon",
+ "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+dependencies = [
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
+ "rayon",
 ]
 
 [[package]]
@@ -89,6 +229,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +245,12 @@ name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bitflags"
@@ -129,6 +281,12 @@ name = "bnum"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56953345e39537a3e18bdaeba4cb0c58a78c1f61f361dc0fa7c5c7340ae87c5f"
+
+[[package]]
+name = "bnum"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e31ea183f6ee62ac8b8a8cf7feddd766317adfb13ff469de57ce033efd6a790"
 
 [[package]]
 name = "bumpalo"
@@ -195,11 +353,17 @@ name = "cosmos_coin"
 version = "0.1.0"
 source = "git+https://github.com/phi-labs-ltd/CosmosCoin.git?rev=857b379#857b3797bd50c0d8b961a64dcb7293bf15b7f002"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.5.11",
  "cw20-base 1.1.2",
  "schemars",
  "serde",
 ]
+
+[[package]]
+name = "cosmwasm-core"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b6dc17e7fd89d0a0a58f12ef33f0bbdf09a6a14c3dfb383eae665e5889250e"
 
 [[package]]
 name = "cosmwasm-crypto"
@@ -208,9 +372,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c82e56962f0f18c9a292aa59940e03a82ce15ef79b93679d5838bb8143f0df"
 dependencies = [
  "digest 0.10.7",
- "ed25519-zebra",
+ "ed25519-zebra 3.1.0",
  "k256",
  "rand_core 0.6.4",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cosmwasm-crypto"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2f53285517db3e33d825b3e46301efe845135778527e1295154413b2f0469e"
+dependencies = [
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "cosmwasm-core",
+ "curve25519-dalek 4.1.3",
+ "digest 0.10.7",
+ "ecdsa",
+ "ed25519-zebra 4.0.3",
+ "k256",
+ "num-traits",
+ "p256",
+ "rand_core 0.6.4",
+ "rayon",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -221,6 +409,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b804ff15a0e059c88f85ae0e868cf8c7aba9d61221e46f1ad7250f270628c7"
 dependencies = [
  "syn 1.0.109",
+]
+
+[[package]]
+name = "cosmwasm-derive"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a782b93fae93e57ca8ad3e9e994e784583f5933aeaaa5c80a545c4b437be2047"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -253,11 +452,11 @@ version = "1.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "763340055b84e5482ed90fec8194ff7d59112267a09bbf5819c9e3edca8c052e"
 dependencies = [
- "base64",
- "bech32",
- "bnum",
- "cosmwasm-crypto",
- "cosmwasm-derive",
+ "base64 0.21.7",
+ "bech32 0.9.1",
+ "bnum 0.10.0",
+ "cosmwasm-crypto 1.5.11",
+ "cosmwasm-derive 1.5.11",
  "derivative",
  "forward_ref",
  "hex",
@@ -270,12 +469,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmwasm-std"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf82335c14bd94eeb4d3c461b7aa419ecd7ea13c2efe24b97cd972bdb8044e7d"
+dependencies = [
+ "base64 0.22.1",
+ "bech32 0.11.0",
+ "bnum 0.11.0",
+ "cosmwasm-core",
+ "cosmwasm-crypto 2.2.2",
+ "cosmwasm-derive 2.2.2",
+ "derive_more",
+ "hex",
+ "rand_core 0.6.4",
+ "rmp-serde",
+ "schemars",
+ "serde",
+ "serde-json-wasm 1.0.1",
+ "sha2 0.10.9",
+ "static_assertions",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "cosmwasm-storage"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66de2ab9db04757bcedef2b5984fbe536903ada4a8a9766717a4a71197ef34f6"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.5.11",
  "serde",
 ]
 
@@ -287,6 +510,31 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-bigint"
@@ -324,12 +572,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "cw-storage-plus"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c087ff98fb0475db4c2b5298a5fd12b2848d2854b39d1115d930ee6da24d1eed"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.5.11",
  "schemars",
  "serde",
 ]
@@ -340,7 +615,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "648b1507290bbc03a8d88463d7cd9b04b1fa0155e5eef366c4fa052b9caaac7a"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.5.11",
  "schemars",
  "serde",
 ]
@@ -351,7 +626,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5ff29294ee99373e2cd5fd21786a3c0ced99a52fec2ca347d565489c61b723c"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.5.11",
  "schemars",
  "serde",
 ]
@@ -362,7 +637,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbaecb78c8e8abfd6b4258c7f4fbeb5c49a5e45ee4d910d3240ee8e1d714e1b"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.5.11",
  "schemars",
  "serde",
  "thiserror 1.0.69",
@@ -375,7 +650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c4a657e5caacc3a0d00ee96ca8618745d050b8f757c709babafb81208d4239c"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-std 1.5.11",
  "cw2 1.1.2",
  "schemars",
  "semver",
@@ -389,7 +664,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f8a6500c396e33f6a7b05d35a5124eb3e394cdb6ca901f7e88332870407896c"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.5.11",
  "cw-storage-plus 0.12.1",
  "schemars",
  "serde",
@@ -401,7 +676,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cf4639517490dd36b333bbd6c4fbd92e325fd0acf4683b41753bc5eb63bfc1"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.5.11",
  "cw-storage-plus 0.13.4",
  "schemars",
  "serde",
@@ -414,7 +689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6c120b24fbbf5c3bedebb97f2cc85fbfa1c3287e09223428e7e597b5293c1fa"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-std 1.5.11",
  "cw-storage-plus 1.2.0",
  "schemars",
  "semver",
@@ -428,7 +703,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cb782b8f110819a4eb5dbbcfed25ffba49ec16bbe32b4ad8da50a5ce68fec05"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.5.11",
  "cw-utils 0.13.4",
  "schemars",
  "serde",
@@ -441,7 +716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "526e39bb20534e25a1cd0386727f0038f4da294e5e535729ba3ef54055246abd"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-std 1.5.11",
  "cw-utils 1.0.3",
  "schemars",
  "serde",
@@ -453,7 +728,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0306e606581f4fb45e82bcbb7f0333179ed53dd949c6523f01a99b4bfc1475a0"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.5.11",
  "cw-storage-plus 0.13.4",
  "cw-utils 0.13.4",
  "cw2 0.13.4",
@@ -470,7 +745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ad79e86ea3707229bf78df94e08732e8f713207b4a77b2699755596725e7d9"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-std 1.5.11",
  "cw-storage-plus 1.2.0",
  "cw2 1.1.2",
  "cw20 1.1.2",
@@ -486,7 +761,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "035818368a74c07dd9ed5c5a93340199ba251530162010b9f34c3809e3b97df1"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.5.11",
  "cw-utils 0.13.4",
  "schemars",
  "serde",
@@ -498,7 +773,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "423d4efe8b649d228d1533e141c238415f49aa8a9ee4e40fce192d7a93ffd057"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.5.11",
  "cw-storage-plus 0.13.4",
  "cw-utils 0.13.4",
  "cw2 0.13.4",
@@ -527,6 +802,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -571,19 +867,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
 name = "ed25519-zebra"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
 dependencies = [
- "curve25519-dalek",
- "hashbrown",
+ "curve25519-dalek 3.2.0",
+ "hashbrown 0.12.3",
  "hex",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.9.9",
  "zeroize",
 ]
+
+[[package]]
+name = "ed25519-zebra"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "ed25519",
+ "hashbrown 0.14.5",
+ "hex",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "zeroize",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -613,6 +939,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "forward_ref"
@@ -754,7 +1086,26 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.12",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.12",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -794,6 +1145,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -875,6 +1235,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +1282,18 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "parking_lot"
@@ -938,7 +1329,7 @@ name = "philabs-cw721-marketplace"
 version = "2.1.1"
 dependencies = [
  "cosmos_coin",
- "cosmwasm-std",
+ "cosmwasm-std 1.5.11",
  "cosmwasm-storage",
  "cw-storage-plus 0.12.1",
  "cw2 0.12.1",
@@ -975,6 +1366,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,6 +1402,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1434,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1032,7 +1481,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33a0110d28bd076f39e14bfd5b0340216dd18effeb5d02b43215944cc3e5c751"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "chrono",
  "futures",
  "paste",
@@ -1059,10 +1508,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustversion"
@@ -1431,6 +1911,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,7 +2119,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+cosmwasm-std = "2.2.2"
 philabs-cw721-marketplace = { path = "./packages/philabs-cw721-marketplace", features = ["library"] }
 rmcp = { version = "0.1.5", features = ["transport-io"] }
 schemars = "0.8.22"

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -1,0 +1,8 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ValidatedExecute {
+    pub execute_msg: String,
+    pub cosmos_msg: String,
+}

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -361,7 +361,80 @@ Call this tool to build a prepared execute message for a transaction to the Ambu
 NFT marketplace contract. This tool won't sign the message, or broadcast it to the 
 blockchain, but can be combined with any RPC connected tx tool that accepts a well-
 formed CosmosMsg for an ExecuteMsg variant for any valid Ambur marketplace contract 
-execute entry point."#;
+execute (tx) entry point.
+
+Note that your chat partner does not need to inform you of any amount of native funds 
+to be sent along with the transaction, this is because Ambur marketplace handles 
+payments using USDC on Archway Network, which is a CW20 token. While the contract does 
+support native token payments (e.g. in ARCH), this is only a legacy feature and ARCH is 
+not currently enabled as an allowed payment option in the contract configuration.
+
+There are three calling parameters required when calling this tool: the Ambur 
+contract address (e.g. either the mainnet or testnet contract address; see tool: 
+'list_contract_deployments'), the amount of native funds to send in the transaction, 
+and the ExecuteMsg variant to be built into a CosmosMsg that can be broadcast by any RPC 
+connected tool.
+
+See the below documentation for more info about funding amounts and the ExecuteMsg variants: 
+
+```DOCUMENTATION_BEGIN
+* All 'create' swaps with swap type 'Sale' must use Archway Network's USDC native 
+coin as the payment token, which has a denom value of 
+'ibc/43897B9739BD63E3A08A88191999C632E052724AB96BD4C74AE31375C991F48D'
+
+* All 'create' swaps with swap type 'Offer' must use Archway Network's wUSDC CW20 coin as 
+the payment token, which has a denom of 'wUSDC' and a contract address of 
+archway1gaf9nw7n8v5lpjz9caxjpps006kxfcrzcuc8y5qp4clslhven2ns2g0ule
+
+* Both USDC and wUSDC have a decimal precision of 6 decimals (10**6)
+
+* Here's an example of a ExecuteMsg variant (e.g. for a Sale 'create' tx) with its required 
+parameter values:
+
+{
+  "create": {
+    "id": "cca4e046-97ba-45b2-841b-9adca039545e",
+    "cw721": "archway1r9qqfl2ptc96frn3tx4k2n967xc64uwxg2j9xn2rvsm882fu04kq3hutsv",
+    "token_id": "840",
+    "payment_token": {
+      "native": {
+        "denom": "ibc/43897B9739BD63E3A08A88191999C632E052724AB96BD4C74AE31375C991F48D"
+      }
+    },
+    "price": "8880000",
+    "swap_type": "Sale",
+    "expires": {
+      "never": {}
+    }
+  }
+}
+
+* Here's an example of a ExecuteMsg variant (e.g. for an Offer 'create' tx) with its required 
+parameter values:
+
+{
+  "create": {
+    "id": "9fb7be1f-0a25-451a-bc5e-31b13d9b850b",
+    "cw721": "archway1r9qqfl2ptc96frn3tx4k2n967xc64uwxg2j9xn2rvsm882fu04kq3hutsv",
+    "token_id": "427",
+    "payment_token": {
+      "cw20": {
+        "address": "archway1gaf9nw7n8v5lpjz9caxjpps006kxfcrzcuc8y5qp4clslhven2ns2g0ule"
+      }
+    },
+    "price": "888888",
+    "swap_type": "Offer",
+    "expires": {
+      "at_time": "1747415615458000000"
+    }
+  }
+}
+
+//XXX TODO: explain how to send funds in the 'finish' tx
+//here
+* All 
+```DOCUMENTATION_END
+"#;
 
 
 // Parameter descriptions

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -208,8 +208,43 @@ pub static BUILD_QUERY_MSG_DESCR: &str = r#"
 Call this tool to build a prepared query message for a query to the Ambur NFT 
 marketplace contract. This tool won't broadcast the query or return the query 
 result, but can be combined with any RPC connected query tool that accepts a 
-well-formed QueryMsg variant for any valid Ambur marketplace contract query entry 
-point."#;
+well-formed Cosmos QueryRequest.
+
+There are two calling parameters required when calling this tool: the Ambur 
+contract address (e.g. either the mainnet or testnet contract address; see tool: 
+'list_contract_deployments'), and QueryMsg variant to be built into a Cosmos 
+QueryRequest.
+
+See the below documentation for more info about QueryMsg variants: 
+
+```DOCUMENTATION_BEGIN
+* Here's an example of a QueryMsg variant (e.g. for the 'list_allowed_payments' query) with 
+no required parameter values:
+
+{
+  "list_allowed_payments": {}
+}
+
+* Here's an example of a QueryMsg variant (e.g. for the 'details' query) with required 
+parameter values:
+
+{
+  "details": {
+    "id": "swap-id-52d709fd-8cfe-45e1"
+  }
+}
+
+* Here's an example of a QueryMsg variant (e.g. for the 'list' query) where the optional 
+parameters are ignored:
+
+{
+  "list": {
+    "limit": null,
+    "start_after": null
+  }
+}
+```DOCUMENTATION_END
+"#;
 
 // Execute
 pub static LIST_TX_ENTRY_POINTS_DESCR: &str = r#"
@@ -325,5 +360,21 @@ pub static BUILD_EXECUTE_MSG_DESCR: &str = r#"
 Call this tool to build a prepared execute message for a transaction to the Ambur 
 NFT marketplace contract. This tool won't sign the message, or broadcast it to the 
 blockchain, but can be combined with any RPC connected tx tool that accepts a well-
-formed ExecuteMsg variant for any valid Ambur marketplace contract execute entry 
-point."#;
+formed CosmosMsg for an ExecuteMsg variant for any valid Ambur marketplace contract 
+execute entry point."#;
+
+
+// Parameter descriptions
+pub static CONTRACT_PARAMETER_DESCR: &str = r#"Either the mainnet or tesnet contract 
+address of the Ambur marketplace (e.g. as can be fetched by calling the 
+'list_contract_deployments' tool)"#;
+
+// build_query_msg(QueryMsg)
+pub static QUERY_MSG_PARAMETER_DESCR: &str = r#"
+The 'QueryMsg' enum variant and its required and/or optional parameter values (if any), 
+needed for building the query as a Cosmos SDK 'QueryRequest' so that the query can be 
+successfully built and prepared to be sent to the Ambur marketplace smart contract. If 
+parameter values are required, they must be collected from your chat partner."#;
+
+// build_execute_msg(ExecuteMsg)
+// pub static EXECUTE_MSG_PARAMETER_DESCR: &str = r#""#;

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -242,6 +242,10 @@ parameters are ignored:
   }
 }
 ```DOCUMENTATION_END
+
+Submit both the `contract_addr` and `query_msg` calling parameters in string format. For 
+example, a `details` QueryMsg variant can be submitted to the tool like this: 
+"{\"details\":{\"id\":\"cca4e046-97ba-45b2-841b-9adca039545e\"}}"
 "#;
 
 // Execute
@@ -422,23 +426,19 @@ parameter values:
   }
 }
 
-//XXX TODO: explain how to send funds in the 'finish' tx
-//here
-* All 
+* Here's the schema for adding a native payment to a transaction to be built (e.g. for 
+'finish' txs with a native payment token):
+
+{
+  "denom": "ibc/43897B9739BD63E3A08A88191999C632E052724AB96BD4C74AE31375C991F48D",
+  "amount": "888888",
+}
+
+**NOTE**: "ibc/43897B9739BD63E3A08A88191999C632E052724AB96BD4C74AE31375C991F48D" is the 
+denom for USDC on Archway Network (which is currently the only allowed native payment 
+token).
 ```DOCUMENTATION_END
-"#;
 
-// Parameter descriptions
-pub static CONTRACT_PARAMETER_DESCR: &str = r#"Either the mainnet or tesnet contract 
-address of the Ambur marketplace (e.g. as can be fetched by calling the 
-'list_contract_deployments' tool)"#;
-
-// build_query_msg(QueryMsg)
-pub static QUERY_MSG_PARAMETER_DESCR: &str = r#"
-The 'QueryMsg' enum variant and its required and/or optional parameter values (if any), 
-needed for building the query as a Cosmos SDK 'QueryRequest' so that the query can be 
-successfully built and prepared to be sent to the Ambur marketplace smart contract. If 
-parameter values are required, they must be collected from your chat partner."#;
-
-// build_execute_msg(ExecuteMsg)
-// pub static EXECUTE_MSG_PARAMETER_DESCR: &str = r#""#;
+Submit all three calling parameters (`contract_addr`, `execute_msg` and `payment`) 
+to tool in string format. For example, use stringified JSON for the `execute_msg` and 
+`payment` calling parameters."#;

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -436,7 +436,6 @@ parameter values:
 ```DOCUMENTATION_END
 "#;
 
-
 // Parameter descriptions
 pub static CONTRACT_PARAMETER_DESCR: &str = r#"Either the mainnet or tesnet contract 
 address of the Ambur marketplace (e.g. as can be fetched by calling the 

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -205,15 +205,13 @@ fees). `fee_percentage` is _not_ currently denominated in basis points.
 
 // Prepare a query message for RPC broadcast
 pub static BUILD_QUERY_MSG_DESCR: &str = r#"
-Call this tool to build a prepared query message for a query to the Ambur NFT 
-marketplace contract. This tool won't broadcast the query or return the query 
-result, but can be combined with any RPC connected query tool that accepts a 
-well-formed Cosmos QueryRequest.
+Call this tool to build a prepared query message for a query to the Ambur NFT marketplace 
+contract. This tool won't broadcast the query or return the query result, but can be 
+combined with any RPC connected query tool that accepts a well-formed Cosmos QueryRequest.
 
-There are two calling parameters required when calling this tool: the Ambur 
-contract address (e.g. either the mainnet or testnet contract address; see tool: 
-'list_contract_deployments'), and QueryMsg variant to be built into a Cosmos 
-QueryRequest.
+There are two calling parameters required when calling this tool: the Ambur contract address 
+('contract_addr', e.g. either the mainnet or testnet contract address; see tool: 
+'list_contract_deployments'), and QueryMsg variant to be built into a Cosmos QueryRequest.
 
 See the below documentation for more info about QueryMsg variants: 
 
@@ -363,17 +361,11 @@ blockchain, but can be combined with any RPC connected tx tool that accepts a we
 formed CosmosMsg for an ExecuteMsg variant for any valid Ambur marketplace contract 
 execute (tx) entry point.
 
-Note that your chat partner does not need to inform you of any amount of native funds 
-to be sent along with the transaction, this is because Ambur marketplace handles 
-payments using USDC on Archway Network, which is a CW20 token. While the contract does 
-support native token payments (e.g. in ARCH), this is only a legacy feature and ARCH is 
-not currently enabled as an allowed payment option in the contract configuration.
-
 There are three calling parameters required when calling this tool: the Ambur 
-contract address (e.g. either the mainnet or testnet contract address; see tool: 
-'list_contract_deployments'), the amount of native funds to send in the transaction, 
-and the ExecuteMsg variant to be built into a CosmosMsg that can be broadcast by any RPC 
-connected tool.
+contract address ('contract_addr', e.g. either the mainnet or testnet contract address; see 
+tool: 'list_contract_deployments'), the amount of native funds ('payment') to send in the 
+transaction, and the ExecuteMsg variant ('execute_msg') to be built into a CosmosMsg that can 
+be signed and broadcast by an RPC connected signing wallet.
 
 See the below documentation for more info about funding amounts and the ExecuteMsg variants: 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,7 +127,7 @@ impl AmburMcp {
         execute_msg: ExecuteMsg,
         #[tool(param)]
         #[schemars(
-            description = "Optionally include native payment funds to be sent in the transaction. Only required for 'finish' txs if payment_token is a native token."
+            description = "Optionally include native payment funds to be sent in the transaction (only required for 'finish' txs if payment_token is a native token)"
         )]
         payment: Option<Coin>,
     ) -> Result<CallToolResult, Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,11 +9,13 @@ use serde::{Deserialize, Serialize};
 use std::error::Error as StdError;
 
 pub mod contract;
+pub mod execute;
 pub mod instruction;
-pub mod query_response;
+pub mod query;
 use crate::contract::*;
+use crate::execute::*;
 use crate::instruction::*;
-use crate::query_response::AllResponse as AllQueryResponse;
+use crate::query::{AllResponse as AllQueryResponse, ValidatedQuery};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn StdError>> {
@@ -92,15 +94,26 @@ impl AmburMcp {
         contract_addr: String,
         #[tool(param)]
         #[schemars(
-            description = "QueryMsg variant and its values needed for building the query as a Cosmos SDK QueryRequest"
+            description = "JSON stringified QueryMsg variant needed for building the query as a Cosmos SDK QueryRequest"
         )]
-        query_msg: QueryMsg,
+        query_msg: String,
     ) -> Result<CallToolResult, Error> {
+        let deserialized: QueryMsg = serde_json::from_str(query_msg.as_str()).unwrap();
         let query_req: QueryRequest<QueryMsg> = QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr,
-            msg: to_json_binary(&query_msg).unwrap_or_default(),
+            msg: to_json_binary(&deserialized).unwrap_or_default(),
         });
-        let serialized: String = serde_json::to_string(&query_req).unwrap_or("".to_string());
+        let serialized_query_req = serde_json::to_string(&query_req);
+        if serialized_query_req.is_err() {
+            return Ok(CallToolResult::error(vec![Content::text(
+                "Error wrapping QueryMsg as QueryRequest",
+            )]));
+        }
+        let valid_query = ValidatedQuery {
+            query_msg,
+            query_request: serialized_query_req.unwrap_or_default(),
+        };
+        let serialized: String = serde_json::to_string(&valid_query).unwrap_or_default();
         Ok(CallToolResult::success(vec![Content::text(serialized)]))
     }
 
@@ -124,25 +137,38 @@ impl AmburMcp {
         #[schemars(
             description = "ExecuteMsg variant and its values needed for building the transaction as a Cosmos SDK CosmosMsg"
         )]
-        execute_msg: ExecuteMsg,
+        execute_msg: String,
         #[tool(param)]
         #[schemars(
             description = "Optionally include native payment funds to be sent in the transaction (only required for 'finish' txs if payment_token is a native token)"
         )]
-        payment: Option<Coin>,
+        payment: Option<String>,
     ) -> Result<CallToolResult, Error> {
         let funds: Vec<Coin> = if payment.is_some() {
-            vec![payment.unwrap_or_default()]
+            let deserialized: Coin =
+                serde_json::from_str(payment.unwrap().as_str()).unwrap_or_default();
+            vec![deserialized]
         } else {
             vec![]
         };
-        let execute_msg: CosmosMsg = WasmMsg::Execute {
+        let deserialized: ExecuteMsg = serde_json::from_str(execute_msg.as_str()).unwrap();
+        let cosmos_msg: CosmosMsg = WasmMsg::Execute {
             contract_addr,
-            msg: to_json_binary(&execute_msg).unwrap_or_default(),
+            msg: to_json_binary(&deserialized).unwrap_or_default(),
             funds,
         }
         .into();
-        let serialized: String = serde_json::to_string(&execute_msg).unwrap_or("".to_string());
+        let serialized_cosmos_msg = serde_json::to_string(&cosmos_msg);
+        if serialized_cosmos_msg.is_err() {
+            return Ok(CallToolResult::error(vec![Content::text(
+                "Error wrapping ExecuteMsg as CosmosMsg",
+            )]));
+        }
+        let valid_execute = ValidatedExecute {
+            execute_msg,
+            cosmos_msg: serialized_cosmos_msg.unwrap_or_default(),
+        };
+        let serialized: String = serde_json::to_string(&valid_execute).unwrap_or_default();
         Ok(CallToolResult::success(vec![Content::text(serialized)]))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use cosmwasm_std::{QueryRequest, to_json_binary, WasmQuery};
 use philabs_cw721_marketplace::msg::{ExecuteMsg, QueryMsg};
 use rmcp::{
     Error, ServerHandler, ServiceExt, model::CallToolResult, model::Content, model::Implementation,
@@ -82,10 +83,21 @@ impl AmburMcp {
     }
 
     #[tool(description = BUILD_QUERY_MSG_DESCR)]
-    async fn build_query_msg(&self) -> Result<CallToolResult, Error> {
-        Ok(CallToolResult::success(vec![Content::text(
-            "todo".to_string(),
-        )]))
+    async fn build_query_msg(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "contract address of Ambur marketplace (e.g. mainnet or testnet address)")]
+        contract_addr: String,
+        #[tool(param)]
+        #[schemars(description = "QueryMsg variant and values needed for building the query as a Cosmos SDK QueryRequest")]
+        query_msg: QueryMsg,
+    ) -> Result<CallToolResult, Error> {
+        let query_req: QueryRequest<QueryMsg> = QueryRequest::Wasm(WasmQuery::Smart {
+            contract_addr,
+            msg: to_json_binary(&query_msg).unwrap_or_default(),
+        });
+        let serialized: String = serde_json::to_string(&query_req).unwrap_or("".to_string());
+        Ok(CallToolResult::success(vec![Content::text(serialized)]))
     }
 
     /// Execute entry point tools

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,4 @@
-use cosmwasm_std::{
-    Coin, CosmosMsg, QueryRequest, to_json_binary, WasmMsg, WasmQuery
-};
+use cosmwasm_std::{Coin, CosmosMsg, QueryRequest, WasmMsg, WasmQuery, to_json_binary};
 use philabs_cw721_marketplace::msg::{ExecuteMsg, QueryMsg};
 use rmcp::{
     Error, ServerHandler, ServiceExt, model::CallToolResult, model::Content, model::Implementation,
@@ -88,10 +86,14 @@ impl AmburMcp {
     async fn build_query_msg(
         &self,
         #[tool(param)]
-        #[schemars(description = "contract address of Ambur marketplace (e.g. mainnet or testnet address)")]
+        #[schemars(
+            description = "contract address of Ambur marketplace (e.g. mainnet or testnet address)"
+        )]
         contract_addr: String,
         #[tool(param)]
-        #[schemars(description = "QueryMsg variant and its values needed for building the query as a Cosmos SDK QueryRequest")]
+        #[schemars(
+            description = "QueryMsg variant and its values needed for building the query as a Cosmos SDK QueryRequest"
+        )]
         query_msg: QueryMsg,
     ) -> Result<CallToolResult, Error> {
         let query_req: QueryRequest<QueryMsg> = QueryRequest::Wasm(WasmQuery::Smart {
@@ -114,19 +116,25 @@ impl AmburMcp {
     async fn build_execute_msg(
         &self,
         #[tool(param)]
-        #[schemars(description = "contract address of Ambur marketplace (e.g. mainnet or testnet address)")]
+        #[schemars(
+            description = "contract address of Ambur marketplace (e.g. mainnet or testnet address)"
+        )]
         contract_addr: String,
         #[tool(param)]
-        #[schemars(description = "ExecuteMsg variant and its values needed for building the transaction as a Cosmos SDK CosmosMsg")]
+        #[schemars(
+            description = "ExecuteMsg variant and its values needed for building the transaction as a Cosmos SDK CosmosMsg"
+        )]
         execute_msg: ExecuteMsg,
         #[tool(param)]
-        #[schemars(description = "Optionally include native payment funds to be sent in the transaction. Only required for 'finish' txs if payment_token is a native token.")]
+        #[schemars(
+            description = "Optionally include native payment funds to be sent in the transaction. Only required for 'finish' txs if payment_token is a native token."
+        )]
         payment: Option<Coin>,
     ) -> Result<CallToolResult, Error> {
-        let funds: Vec<Coin> = if payment.is_some() { 
-            vec![payment.unwrap_or_default()] 
-        } else { 
-            vec![] 
+        let funds: Vec<Coin> = if payment.is_some() {
+            vec![payment.unwrap_or_default()]
+        } else {
+            vec![]
         };
         let execute_msg: CosmosMsg = WasmMsg::Execute {
             contract_addr,

--- a/src/query.rs
+++ b/src/query.rs
@@ -11,3 +11,9 @@ pub struct AllResponse {
     pub collection_royalties_response: CollectionRoyaltiesResponse,
     pub collection_offer_details_response: CollectionOfferDetailsResponse,
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ValidatedQuery {
+    pub query_msg: String,
+    pub query_request: String,
+}


### PR DESCRIPTION
This PR adds tools for building and validating query and execute messages to the Ambur MCP server. Additionally, it improves the agent instructions.

The new tools are: 
- `build_query_msg`
- `build_execute_msg`

The tool return types are JSON stringified versions of the following structs:

```rs
pub struct ValidatedQuery {
    pub query_msg: String, // JSON version for building the query with cosm.js
    pub query_request: String, // protobuf encoded version for immediate broadcast
}
```

```rs
pub struct ValidatedExecute {
    pub execute_msg: String, // JSON version for building the tx with cosm.js
    pub cosmos_msg: String, // protobuf encoded version for direct signing + broadcast
}
```