### PR TITLE
Feature/minter support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,10 +50,13 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 name = "ambur-mcp"
 version = "0.1.0"
 dependencies = [
+ "ambur-wl-minter",
  "ambur-wl-token",
  "archies-token",
  "cosmwasm-std 2.2.2",
+ "derpies-minter",
  "derpies-token",
+ "ghouls-minter",
  "ghouls-token",
  "philabs-cw721-marketplace",
  "rmcp",
@@ -61,6 +64,41 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "whitelist-minter",
+]
+
+[[package]]
+name = "ambur-registry"
+version = "0.1.2"
+source = "git+https://github.com/phi-labs-ltd/ambur-registry.git#18cd92998550cd604c1bbb9196ac282677215093"
+dependencies = [
+ "archway-bindings",
+ "cosmwasm-schema",
+ "cosmwasm-std 1.5.11",
+ "cosmwasm-storage",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
+ "cw721-base 0.18.0",
+ "schemars",
+ "serde",
+ "serde-json-wasm 1.0.1",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ambur-wl-minter"
+version = "1.1.3"
+dependencies = [
+ "ambur-registry",
+ "ambur-wl-token",
+ "cosmwasm-schema",
+ "cosmwasm-std 1.5.11",
+ "cw-storage-plus 0.14.0",
+ "cw2 0.14.0",
+ "schemars",
+ "serde",
+ "serde-json-wasm 1.0.1",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -103,6 +141,19 @@ dependencies = [
  "cw2 0.11.1",
  "cw721-base-updatable",
  "cw721-updatable",
+ "schemars",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "archway-bindings"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6cd100a318332b448d19f0c87306f2170d98221c6fce2e92288351bc26bf24"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std 1.5.11",
  "schemars",
  "serde",
  "thiserror 1.0.69",
@@ -702,6 +753,17 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c8b264257c4f44c49b7ce09377af63aa040768ecd3fd7bdd2d48a09323a1e90"
+dependencies = [
+ "cosmwasm-std 1.5.11",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw-storage-plus"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b6f91c0b94481a3e9ef1ceb183c37d00764f8751e39b45fc09f4d9b970d469"
@@ -796,6 +858,18 @@ checksum = "04cf4639517490dd36b333bbd6c4fbd92e325fd0acf4683b41753bc5eb63bfc1"
 dependencies = [
  "cosmwasm-std 1.5.11",
  "cw-storage-plus 0.13.4",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw2"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa74c324af8e3506fd8d50759a265bead3f87402e413c840042af5d2808463d6"
+dependencies = [
+ "cosmwasm-std 1.5.11",
+ "cw-storage-plus 0.14.0",
  "schemars",
  "serde",
 ]
@@ -1065,6 +1139,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derpies-minter"
+version = "1.1.3"
+dependencies = [
+ "ambur-registry",
+ "ambur-wl-minter",
+ "cosmos_coin",
+ "cosmwasm-schema",
+ "cosmwasm-std 1.5.11",
+ "cosmwasm-storage",
+ "cw-storage-plus 0.14.0",
+ "cw2 0.14.0",
+ "derpies-token",
+ "outpost-router",
+ "philabs-cw721-marketplace",
+ "schemars",
+ "serde",
+ "serde-json-wasm 1.0.1",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "derpies-token"
 version = "0.1.0"
 dependencies = [
@@ -1319,6 +1414,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghouls-minter"
+version = "0.2.6"
+dependencies = [
+ "ambur-wl-minter",
+ "cosmwasm-schema",
+ "cosmwasm-std 1.5.11",
+ "cw-storage-plus 0.14.0",
+ "cw2 0.14.0",
+ "cw721-metadata 0.1.0 (git+https://github.com/archway-network/cw721-metadata.git?rev=4c008ca)",
+ "cw721-updatable",
+ "ghouls-token",
+ "philabs-cw721-marketplace",
+ "schemars",
+ "serde",
+ "serde-json-wasm 1.0.1",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ghouls-token"
 version = "0.1.2"
 source = "git+https://github.com/phi-labs-ltd/ghouls-token.git#1dab69a62ca84430030a6d27b98fcc3c8c7df486"
@@ -1552,6 +1666,47 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "outpost-rand"
+version = "0.1.1"
+dependencies = [
+ "cosmwasm-std 1.5.11",
+]
+
+[[package]]
+name = "outpost-router"
+version = "0.1.1"
+dependencies = [
+ "archway-bindings",
+ "cosmwasm-schema",
+ "cosmwasm-std 1.5.11",
+ "cosmwasm-storage",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
+ "outpost-rand",
+ "outpost-storage",
+ "schemars",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "outpost-storage"
+version = "0.1.1"
+dependencies = [
+ "archway-bindings",
+ "cosmwasm-schema",
+ "cosmwasm-std 1.5.11",
+ "cosmwasm-storage",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
+ "cw721-metadata 0.1.0 (git+https://github.com/archway-network/cw721-metadata.git?rev=4c008ca)",
+ "outpost-rand",
+ "schemars",
+ "serde",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "p256"
@@ -2254,6 +2409,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "whitelist-minter"
+version = "1.0.1"
+dependencies = [
+ "archies-token",
+ "cosmwasm-std 1.5.11",
+ "cw-storage-plus 0.14.0",
+ "cw2 0.14.0",
+ "cw721-updatable",
+ "schemars",
+ "serde",
+ "serde-json-wasm 1.0.1",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,14 @@ serde = "1.0.219"
 serde_json = "1.0.140"
 tokio = { version = "1.44.2", features = ["full"] }
 
+# cw721 tokens
 ambur-wl-token = { path = "./packages/ambur-whitelist-ticket/contracts/token", features = ["library"] }
 archies-token = { git = "https://github.com/phi-labs-ltd/archies-token.git", version = "0.1.0", features = ["library"] }
 derpies-token = { path = "./packages/derpies-minter/contracts/token", features = ["library"] }
 ghouls-token = { git = "https://github.com/phi-labs-ltd/ghouls-token.git", version = "0.1.0", features = ["library"] }
+
+# cw721 minters
+ambur-wl-minter = { path = "./packages/ambur-whitelist-ticket/contracts/minter", features = ["library"] }
+derpies-minter = { path = "./packages/derpies-minter/contracts/minter", features = ["library"] }
+ghouls-minter = { path = "./packages/ghouls-minter", features = ["library"] }
+whitelist-minter = { path = "./packages/archies-whitelist-minter", features = ["library"] }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -473,8 +473,7 @@ pub static BUILD_TOKEN_EXECUTE_MSG_DESCR: &str =
     "Build an execute message (tx) for a cw721 contract of a token that can be traded on Ambur";
 
 // Minter Query
-pub static LIST_MINTER_QUERY_ENTRY_POINTS_DESCR: &str =
-    "List all contract query entry points for the minter contract of a cw721 token that can be traded on Ambur";
+pub static LIST_MINTER_QUERY_ENTRY_POINTS_DESCR: &str = "List all contract query entry points for the minter contract of a cw721 token that can be traded on Ambur";
 pub static BUILD_MINTER_QUERY_MSG_DESCR: &str =
     "Build a contract query for the minter contract of a cw721 token that can be traded on Ambur";
 

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -473,5 +473,12 @@ pub static BUILD_TOKEN_EXECUTE_MSG_DESCR: &str =
     "Build an execute message (tx) for a cw721 contract of a token that can be traded on Ambur";
 
 // Minter Query
+pub static LIST_MINTER_QUERY_ENTRY_POINTS_DESCR: &str =
+    "List all contract query entry points for the minter contract of a cw721 token that can be traded on Ambur";
+pub static BUILD_MINTER_QUERY_MSG_DESCR: &str =
+    "Build a contract query for the minter contract of a cw721 token that can be traded on Ambur";
 
 // Minter Execute
+pub static LIST_MINTER_TX_ENTRY_POINTS_DESCR: &str = "List all execute entry points (txs) that can be made to the minter contract for an NFT collection that can be traded on Ambur";
+pub static BUILD_MINTER_EXECUTE_MSG_DESCR: &str =
+    "Build an execute message (tx) for the minter contract of a token that can be traded on Ambur";

--- a/src/server/ambur.rs
+++ b/src/server/ambur.rs
@@ -12,6 +12,7 @@ use crate::execute::*;
 use crate::instruction::*;
 use crate::network::*;
 use crate::query::{AllResponse as AllQueryResponse, ValidatedQuery};
+use crate::server::minter::*;
 use crate::server::token::*;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -440,6 +441,218 @@ impl AmburMcp {
             }
             "foresight" | "the foresight ticket" => {
                 let deserialized: ForesightExecuteMsg =
+                    serde_json::from_str(execute_msg.as_str()).unwrap();
+                let cosmos_msg: CosmosMsg = WasmMsg::Execute {
+                    contract_addr,
+                    msg: to_json_binary(&deserialized).unwrap_or_default(),
+                    funds: vec![],
+                }
+                .into();
+                Some(cosmos_msg)
+            }
+            _ => None,
+        };
+        if cosmos_msg.is_none() {
+            return Ok(CallToolResult::error(vec![Content::text(
+                "Error deserializing execute_msg to ExecuteMsg",
+            )]));
+        }
+        let serialized_cosmos_msg = serde_json::to_string(&cosmos_msg);
+        if serialized_cosmos_msg.is_err() {
+            return Ok(CallToolResult::error(vec![Content::text(
+                "Error wrapping ExecuteMsg as CosmosMsg",
+            )]));
+        }
+        let valid_execute = ValidatedExecute {
+            execute_msg,
+            cosmos_msg: serialized_cosmos_msg.unwrap_or_default(),
+        };
+        let serialized: String = serde_json::to_string(&valid_execute).unwrap_or_default();
+        Ok(CallToolResult::success(vec![Content::text(serialized)]))
+    }
+
+    // Minter Query entry point tools
+    #[tool(description = LIST_MINTER_QUERY_ENTRY_POINTS_DESCR)]
+    async fn list_minter_query_entry_points(
+        &self,
+        #[tool(param)]
+        #[schemars(
+            description = "name of the NFT collection (e.g. \"archies\", \"the foresight ticket\", \"derpies\", \"ghouls\")"
+        )]
+        nft: String,
+    ) -> Result<CallToolResult, Error> {
+        let schema = match nft.to_lowercase().as_str() {
+            "archies" => Some(schema_for!(ArchiesMinterQueryMsg)),
+            "derpies" => Some(schema_for!(DerpiesMinterQueryMsg)),
+            "ghouls" => Some(schema_for!(GhoulsMinterQueryMsg)),
+            "foresight" | "the foresight ticket" => {
+                Some(schema_for!(ForesightMinterQueryMsg))
+            }
+            _ => None,
+        };
+        if schema.is_none() {
+            let err_msg = "Unrecognized NFT collection name ".to_string() + &nft;
+            return Ok(CallToolResult::error(vec![Content::text(&err_msg)]));
+        }
+        let schema = schema.unwrap();
+        let serialized: String = serde_json::to_string(&schema).unwrap_or("".to_string());
+        Ok(CallToolResult::success(vec![Content::text(serialized)]))
+    }
+    
+    #[tool(description = BUILD_MINTER_QUERY_MSG_DESCR)]
+    async fn build_minter_query_msg(
+        &self,
+        #[tool(param)]
+        #[schemars(
+            description = "name of the NFT collection (e.g. \"archies\", \"the foresight ticket\", \"derpies\", \"ghouls\")"
+        )]
+        nft: String,
+        #[tool(param)]
+        #[schemars(description = "contract address of minter contract")]
+        contract_addr: String,
+        #[tool(param)]
+        #[schemars(
+            description = "JSON stringified QueryMsg variant needed for building the query as a Cosmos SDK QueryRequest"
+        )]
+        query_msg: String,
+    ) -> Result<CallToolResult, Error> {
+        let query_req: Option<QueryRequest> = match nft.to_lowercase().as_str() {
+            "archies" => {
+                let deserialized: ArchiesMinterQueryMsg =
+                    serde_json::from_str(query_msg.as_str()).unwrap();
+                let query_req = QueryRequest::Wasm(WasmQuery::Smart {
+                    contract_addr,
+                    msg: to_json_binary(&deserialized).unwrap_or_default(),
+                });
+                Some(query_req)
+            }
+            "derpies" => {
+                let deserialized: DerpiesMinterQueryMsg =
+                    serde_json::from_str(query_msg.as_str()).unwrap();
+                let query_req = QueryRequest::Wasm(WasmQuery::Smart {
+                    contract_addr,
+                    msg: to_json_binary(&deserialized).unwrap_or_default(),
+                });
+                Some(query_req)
+            }
+            "ghouls" => {
+                let deserialized: GhoulsMinterQueryMsg =
+                    serde_json::from_str(query_msg.as_str()).unwrap();
+                let query_req = QueryRequest::Wasm(WasmQuery::Smart {
+                    contract_addr,
+                    msg: to_json_binary(&deserialized).unwrap_or_default(),
+                });
+                Some(query_req)
+            }
+            "foresight" | "the foresight ticket" => {
+                let deserialized: ForesightMinterQueryMsg =
+                    serde_json::from_str(query_msg.as_str()).unwrap();
+                let query_req = QueryRequest::Wasm(WasmQuery::Smart {
+                    contract_addr,
+                    msg: to_json_binary(&deserialized).unwrap_or_default(),
+                });
+                Some(query_req)
+            }
+            _ => None,
+        };
+        if query_req.is_none() {
+            return Ok(CallToolResult::error(vec![Content::text(
+                "Error deserializing token QueryMsg",
+            )]));
+        }
+        let serialized_query_req = serde_json::to_string(&query_req);
+        if serialized_query_req.is_err() {
+            return Ok(CallToolResult::error(vec![Content::text(
+                "Error wrapping token QueryMsg as QueryRequest",
+            )]));
+        }
+        let valid_query = ValidatedQuery {
+            query_msg,
+            query_request: serialized_query_req.unwrap_or_default(),
+        };
+        let serialized: String = serde_json::to_string(&valid_query).unwrap_or_default();
+        Ok(CallToolResult::success(vec![Content::text(serialized)]))
+    }
+
+    // Minter Execute entry point tools
+    #[tool(description = LIST_MINTER_TX_ENTRY_POINTS_DESCR)]
+    async fn list_minter_tx_entry_points(
+        &self,
+        #[tool(param)]
+        #[schemars(
+            description = "name of the NFT collection (e.g. \"archies\", \"the foresight ticket\", \"derpies\", \"ghouls\")"
+        )]
+        nft: String,
+    ) -> Result<CallToolResult, Error> {
+        let schema = match nft.to_lowercase().as_str() {
+            "archies" => Some(schema_for!(ArchiesMinterExecuteMsg)),
+            "derpies" => Some(schema_for!(DerpiesMinterExecuteMsg)),
+            "ghouls" => Some(schema_for!(GhoulsMinterExecuteMsg)),
+            "foresight" | "the foresight ticket" => Some(schema_for!(ForesightMinterExecuteMsg)),
+            _ => None,
+        };
+        if schema.is_none() {
+            let err_msg = "Unrecognized NFT collection name ".to_string() + &nft;
+            return Ok(CallToolResult::error(vec![Content::text(&err_msg)]));
+        }
+        let schema = schema.unwrap();
+        let serialized: String = serde_json::to_string(&schema).unwrap_or("".to_string());
+        Ok(CallToolResult::success(vec![Content::text(serialized)]))
+    }
+
+    #[tool(description = BUILD_MINTER_EXECUTE_MSG_DESCR)]
+    async fn build_minter_execute_msg(
+        &self,
+        #[tool(param)]
+        #[schemars(
+            description = "name of the NFT collection (e.g. \"archies\", \"the foresight ticket\", \"derpies\", \"ghouls\")"
+        )]
+        nft: String,
+        #[tool(param)]
+        #[schemars(description = "contract address of minter contract")]
+        contract_addr: String,
+        #[tool(param)]
+        #[schemars(
+            description = "ExecuteMsg variant and its values needed for building the transaction as a Cosmos SDK CosmosMsg"
+        )]
+        execute_msg: String,
+    ) -> Result<CallToolResult, Error> {
+        let cosmos_msg: Option<CosmosMsg> = match nft.to_lowercase().as_str() {
+            "archies" => {
+                let deserialized: ArchiesMinterExecuteMsg =
+                    serde_json::from_str(execute_msg.as_str()).unwrap();
+                let cosmos_msg: CosmosMsg = WasmMsg::Execute {
+                    contract_addr,
+                    msg: to_json_binary(&deserialized).unwrap_or_default(),
+                    funds: vec![],
+                }
+                .into();
+                Some(cosmos_msg)
+            }
+            "derpies" => {
+                let deserialized: DerpiesMinterExecuteMsg =
+                    serde_json::from_str(execute_msg.as_str()).unwrap();
+                let cosmos_msg: CosmosMsg = WasmMsg::Execute {
+                    contract_addr,
+                    msg: to_json_binary(&deserialized).unwrap_or_default(),
+                    funds: vec![],
+                }
+                .into();
+                Some(cosmos_msg)
+            }
+            "ghouls" => {
+                let deserialized: GhoulsMinterExecuteMsg =
+                    serde_json::from_str(execute_msg.as_str()).unwrap();
+                let cosmos_msg: CosmosMsg = WasmMsg::Execute {
+                    contract_addr,
+                    msg: to_json_binary(&deserialized).unwrap_or_default(),
+                    funds: vec![],
+                }
+                .into();
+                Some(cosmos_msg)
+            }
+            "foresight" | "the foresight ticket" => {
+                let deserialized: ForesightMinterExecuteMsg =
                     serde_json::from_str(execute_msg.as_str()).unwrap();
                 let cosmos_msg: CosmosMsg = WasmMsg::Execute {
                     contract_addr,

--- a/src/server/ambur.rs
+++ b/src/server/ambur.rs
@@ -485,9 +485,7 @@ impl AmburMcp {
             "archies" => Some(schema_for!(ArchiesMinterQueryMsg)),
             "derpies" => Some(schema_for!(DerpiesMinterQueryMsg)),
             "ghouls" => Some(schema_for!(GhoulsMinterQueryMsg)),
-            "foresight" | "the foresight ticket" => {
-                Some(schema_for!(ForesightMinterQueryMsg))
-            }
+            "foresight" | "the foresight ticket" => Some(schema_for!(ForesightMinterQueryMsg)),
             _ => None,
         };
         if schema.is_none() {
@@ -498,7 +496,7 @@ impl AmburMcp {
         let serialized: String = serde_json::to_string(&schema).unwrap_or("".to_string());
         Ok(CallToolResult::success(vec![Content::text(serialized)]))
     }
-    
+
     #[tool(description = BUILD_MINTER_QUERY_MSG_DESCR)]
     async fn build_minter_query_msg(
         &self,

--- a/src/server/minter.rs
+++ b/src/server/minter.rs
@@ -1,0 +1,12 @@
+pub use ambur_wl_minter::msg::{
+    ExecuteMsg as ForesightMinterExecuteMsg, QueryMsg as ForesightMinterQueryMsg,
+};
+pub use derpies_minter::msg::{
+    ExecuteMsg as DerpiesMinterExecuteMsg, QueryMsg as DerpiesMinterQueryMsg,
+};
+pub use ghouls_minter::msg::{
+    ExecuteMsg as GhoulsMinterExecuteMsg, QueryMsg as GhoulsMinterQueryMsg,
+};
+pub use whitelist_minter::msg::{
+    ExecuteMsg as ArchiesMinterExecuteMsg, QueryMsg as ArchiesMinterQueryMsg,
+};

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,2 +1,3 @@
 pub mod ambur;
+pub mod minter;
 pub mod token;


### PR DESCRIPTION
This PR expands the Ambur MCP server to support the NFT minter contracts for the following collections:

* Archies
* The Foresight Ticket
* Derpies
* Ghouls

After expanding the MCP server to support the minter contracts, there are now 15 tools available in total. The following is a list of the new (token contract) tools that are being added in this PR:

* `list_minter_query_entry_points` - Lists the queries that can be made to a minter contract for an NFT that can be traded on Ambur
* `build_minter_query_msg` - Build a query to a minter contract for an NFT token that can be traded on Ambur that can be broadcast by an RPC connected wallet
* `list_minter_tx_entry_points` - Lists the transactions that can be made to a minter contract for an NFT token that can be traded on Ambur 
* `build_minter_execute_msg` - Build a transaction to a minter contract for an NFT token that can be traded on Ambur that can be broadcast by an RPC connected wallet