### PR TITLE
Remove local cargo dependencies and use ssh instead

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[net]
+git-fetch-with-cli = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
  "derpies-token",
  "ghouls-minter",
  "ghouls-token",
- "philabs-cw721-marketplace",
+ "philabs-cw721-marketplace 2.1.1 (git+ssh://git@github.com/phi-labs-ltd/philabs-cw721-marketplace.git)",
  "rmcp",
  "schemars",
  "serde",
@@ -1152,7 +1152,7 @@ dependencies = [
  "cw2 0.14.0",
  "derpies-token",
  "outpost-router",
- "philabs-cw721-marketplace",
+ "philabs-cw721-marketplace 2.1.1",
  "schemars",
  "serde",
  "serde-json-wasm 1.0.1",
@@ -1425,7 +1425,7 @@ dependencies = [
  "cw721-metadata 0.1.0 (git+https://github.com/archway-network/cw721-metadata.git?rev=4c008ca)",
  "cw721-updatable",
  "ghouls-token",
- "philabs-cw721-marketplace",
+ "philabs-cw721-marketplace 2.1.1",
  "schemars",
  "serde",
  "serde-json-wasm 1.0.1",
@@ -1752,6 +1752,26 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "philabs-cw721-marketplace"
 version = "2.1.1"
+dependencies = [
+ "cosmos_coin",
+ "cosmwasm-std 1.5.11",
+ "cosmwasm-storage",
+ "cw-storage-plus 0.12.1",
+ "cw2 0.12.1",
+ "cw20 0.13.4",
+ "cw20-base 0.13.4",
+ "cw721 0.13.4",
+ "cw721-base 0.13.4",
+ "schemars",
+ "serde",
+ "serde-json-wasm 1.0.1",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "philabs-cw721-marketplace"
+version = "2.1.1"
+source = "git+ssh://git@github.com/phi-labs-ltd/philabs-cw721-marketplace.git#b5621289e60c976dda08b81edbdb9ab7f288cfde"
 dependencies = [
  "cosmos_coin",
  "cosmwasm-std 1.5.11",
@@ -2414,6 +2434,7 @@ dependencies = [
 [[package]]
 name = "whitelist-minter"
 version = "1.0.1"
+source = "git+ssh://git@github.com/phi-labs-ltd/archies-whitelist-minter.git#372dd6cf74e83e406e42e095a95af5b99d72d504"
 dependencies = [
  "archies-token",
  "cosmwasm-std 1.5.11",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
  "derpies-token",
  "ghouls-minter",
  "ghouls-token",
- "philabs-cw721-marketplace 2.1.1 (git+ssh://git@github.com/phi-labs-ltd/philabs-cw721-marketplace.git)",
+ "philabs-cw721-marketplace",
  "rmcp",
  "schemars",
  "serde",
@@ -88,6 +88,7 @@ dependencies = [
 [[package]]
 name = "ambur-wl-minter"
 version = "1.1.3"
+source = "git+ssh://git@github.com/phi-labs-ltd/ambur-whitelist-ticket.git#88e7825dc011c33a881fc7f563a3126106016ecd"
 dependencies = [
  "ambur-registry",
  "ambur-wl-token",
@@ -104,6 +105,7 @@ dependencies = [
 [[package]]
 name = "ambur-wl-token"
 version = "0.1.1"
+source = "git+ssh://git@github.com/phi-labs-ltd/ambur-whitelist-ticket.git#88e7825dc011c33a881fc7f563a3126106016ecd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std 1.5.11",
@@ -1141,6 +1143,7 @@ dependencies = [
 [[package]]
 name = "derpies-minter"
 version = "1.1.3"
+source = "git+ssh://git@github.com/phi-labs-ltd/derpies-minter.git#ca6948b385f5b281da478a515e09e65c9755ccf0"
 dependencies = [
  "ambur-registry",
  "ambur-wl-minter",
@@ -1152,7 +1155,7 @@ dependencies = [
  "cw2 0.14.0",
  "derpies-token",
  "outpost-router",
- "philabs-cw721-marketplace 2.1.1",
+ "philabs-cw721-marketplace",
  "schemars",
  "serde",
  "serde-json-wasm 1.0.1",
@@ -1162,6 +1165,7 @@ dependencies = [
 [[package]]
 name = "derpies-token"
 version = "0.1.0"
+source = "git+ssh://git@github.com/phi-labs-ltd/derpies-minter.git#ca6948b385f5b281da478a515e09e65c9755ccf0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std 1.5.11",
@@ -1416,6 +1420,7 @@ dependencies = [
 [[package]]
 name = "ghouls-minter"
 version = "0.2.6"
+source = "git+ssh://git@github.com/phi-labs-ltd/ghouls-minter.git#f3fcd75a6efc66d66826b1a40a0ffda64f59e474"
 dependencies = [
  "ambur-wl-minter",
  "cosmwasm-schema",
@@ -1425,7 +1430,7 @@ dependencies = [
  "cw721-metadata 0.1.0 (git+https://github.com/archway-network/cw721-metadata.git?rev=4c008ca)",
  "cw721-updatable",
  "ghouls-token",
- "philabs-cw721-marketplace 2.1.1",
+ "philabs-cw721-marketplace",
  "schemars",
  "serde",
  "serde-json-wasm 1.0.1",
@@ -1670,6 +1675,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "outpost-rand"
 version = "0.1.1"
+source = "git+ssh://git@github.com/phi-labs-ltd/outpost.git#cb5360672e4a711fa1096a29b5ec9b2943540de4"
 dependencies = [
  "cosmwasm-std 1.5.11",
 ]
@@ -1677,6 +1683,7 @@ dependencies = [
 [[package]]
 name = "outpost-router"
 version = "0.1.1"
+source = "git+ssh://git@github.com/phi-labs-ltd/outpost.git#cb5360672e4a711fa1096a29b5ec9b2943540de4"
 dependencies = [
  "archway-bindings",
  "cosmwasm-schema",
@@ -1694,6 +1701,7 @@ dependencies = [
 [[package]]
 name = "outpost-storage"
 version = "0.1.1"
+source = "git+ssh://git@github.com/phi-labs-ltd/outpost.git#cb5360672e4a711fa1096a29b5ec9b2943540de4"
 dependencies = [
  "archway-bindings",
  "cosmwasm-schema",
@@ -1748,25 +1756,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "philabs-cw721-marketplace"
-version = "2.1.1"
-dependencies = [
- "cosmos_coin",
- "cosmwasm-std 1.5.11",
- "cosmwasm-storage",
- "cw-storage-plus 0.12.1",
- "cw2 0.12.1",
- "cw20 0.13.4",
- "cw20-base 0.13.4",
- "cw721 0.13.4",
- "cw721-base 0.13.4",
- "schemars",
- "serde",
- "serde-json-wasm 1.0.1",
- "thiserror 1.0.69",
-]
 
 [[package]]
 name = "philabs-cw721-marketplace"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,13 @@ serde_json = "1.0.140"
 tokio = { version = "1.44.2", features = ["full"] }
 
 # cw721 tokens
-ambur-wl-token = { path = "./packages/ambur-whitelist-ticket/contracts/token", features = ["library"] }
+ambur-wl-token = { git = "ssh://git@github.com/phi-labs-ltd/ambur-whitelist-ticket.git", version = "0.1.1" }
 archies-token = { git = "https://github.com/phi-labs-ltd/archies-token.git", version = "0.1.0", features = ["library"] }
-derpies-token = { path = "./packages/derpies-minter/contracts/token", features = ["library"] }
+derpies-token = { git = "ssh://git@github.com/phi-labs-ltd/derpies-minter.git", version = "0.1.0", features = ["library"] }
 ghouls-token = { git = "https://github.com/phi-labs-ltd/ghouls-token.git", version = "0.1.0", features = ["library"] }
 
 # cw721 minters
-ambur-wl-minter = { path = "./packages/ambur-whitelist-ticket/contracts/minter", features = ["library"] }
-derpies-minter = { path = "./packages/derpies-minter/contracts/minter", features = ["library"] }
-ghouls-minter = { path = "./packages/ghouls-minter", features = ["library"] }
-
+ambur-wl-minter = { git = "ssh://git@github.com/phi-labs-ltd/ambur-whitelist-ticket.git", version = "1.1.3", features = ["library"] }
+derpies-minter = { git = "ssh://git@github.com/phi-labs-ltd/derpies-minter.git", version = "1.1.3", features = ["library"] }
+ghouls-minter = { git = "ssh://git@github.com/phi-labs-ltd/ghouls-minter.git", version = "0.2.6", features = ["library"] }
 whitelist-minter = { git = "ssh://git@github.com/phi-labs-ltd/archies-whitelist-minter.git", version = "1.0.1", features = ["library"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 cosmwasm-std = "2.2.2"
-philabs-cw721-marketplace = { path = "./packages/philabs-cw721-marketplace", features = ["library"] }
+philabs-cw721-marketplace = { git = "ssh://git@github.com/phi-labs-ltd/philabs-cw721-marketplace.git", version = "2.1.1", features = ["library"] }
 rmcp = { version = "0.1.5", features = ["transport-io"] }
 schemars = "0.8.22"
 serde = "1.0.219"
@@ -22,4 +22,5 @@ ghouls-token = { git = "https://github.com/phi-labs-ltd/ghouls-token.git", versi
 ambur-wl-minter = { path = "./packages/ambur-whitelist-ticket/contracts/minter", features = ["library"] }
 derpies-minter = { path = "./packages/derpies-minter/contracts/minter", features = ["library"] }
 ghouls-minter = { path = "./packages/ghouls-minter", features = ["library"] }
-whitelist-minter = { path = "./packages/archies-whitelist-minter", features = ["library"] }
+
+whitelist-minter = { git = "ssh://git@github.com/phi-labs-ltd/archies-whitelist-minter.git", version = "1.0.1", features = ["library"] }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 MCP server in Rust, for wrapping Ambur query and execute entry point messages to be broadcast by a signer.
 
 ### Configuring dependencies
-Some dependencies in `Cargo.toml` are provided by GitHub repositories. Public repositories will require no extra configuration, but private repositories must be cloned into the `./packages` folder. This project will not compile unless all GitHub dependencies from private repositories are cloned into `./packages`.
+Some dependencies in `Cargo.toml` are provided by GitHub repositories, including some repositories which are private. If you don't have read access to the private repositories, unfortunately, you will not be able to build this project. 
+
+This project remains open source as it provides examples for developers building an MCP server for multiple CosmWasm contracts. If you're looking for an example you can build and test yourself check out the [cosmwasm-mcp-template](https://github.com/archway-network/cosmwasm-mcp-template) repository; it shares most of the same code as this repository, but doesn't rely on any private dependencies. The main difference between the two projects being, the [cosmwasm-mcp-template](https://github.com/archway-network/cosmwasm-mcp-template) doesn't include multi-contract support.
 
 ### Building this project
 


### PR DESCRIPTION
This PR switches all local dependencies that were using `path`, over to GitHub ssh dependencies. This makes it significantly easier to build the project, and building should now be achievable by anyone without their having to compile and build a bunch of other projects first.